### PR TITLE
Add cuda check in fsdp

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -2992,7 +2992,7 @@ class FullyShardedDataParallel(nn.Module):
                 yield
             return
 
-        if torch.cuda.is_available():
+        if self.compute_device != torch.device("cpu"):
             torch.cuda.synchronize()
         self._lazy_init()
         self._assert_state([TrainingState_.IDLE])

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -2992,7 +2992,8 @@ class FullyShardedDataParallel(nn.Module):
                 yield
             return
 
-        torch.cuda.synchronize()
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
         self._lazy_init()
         self._assert_state([TrainingState_.IDLE])
         for handle in self._handles:


### PR DESCRIPTION
The command is:
```bash
CCL_ATL_TRANSPORT=ofi mpirun -n 2 python examples/pytorch/language-modeling/run_clm.py --torch_dtype auto --model_name_or_path  EleutherAI/gpt-j-6B  --dataset_name wikitext --dataset_config_name wikitext-2-raw-v1  --per_device_train_batch_size 2  --per_device_eval_batch_size 4  --num_train_epochs 1 --fsdp "full_shard auto_wrap" --fsdp_transformer_layer_cls_to_wrap GPTJBlock --output_dir ./output --no_cuda --xpu_backend ccl --do_train --overwrite_output_dir
```
Fix error:
```bash
Traceback (most recent call last):
    File "examples/pytorch/language-modeling/run_clm.py", line 607, in <module>
    main()
    File "examples/pytorch/language-modeling/run_clm.py", line 556, in main
    trainer.save_model()  # Saves the tokenizer too for easy upload
    File "conda_env/lib/python3.7/site-packages/transformers/trainer.py", line 2629, in save_model
    state_dict = self.model.state_dict()
    File "conda_env/lib/python3.7/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 2423, in state_dict
    with summon_ctx:
    File "conda_env/lib/python3.7/contextlib.py", line 112, in __enter__
    return next(self.gen)
    File "conda_env/lib/python3.7/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 2995, in _summon_full_params
    torch.cuda.synchronize()
    File "conda_env/lib/python3.7/site-packages/torch/cuda/__init__.py", line 564, in synchronize
    _lazy_init()
    File "conda_env/lib/python3.7/site-packages/torch/cuda/__init__.py", line 221, in _lazy_init
    raise AssertionError("Torch not compiled with CUDA enabled")
AssertionError: Torch not compiled with CUDA enabled
```